### PR TITLE
index.jsでshow_book_controller.jsの重複読み込みの削除

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,6 +2,3 @@
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
-
-import ShowBookController from "./show_book_controller"
-application.register("show-book", ShowBookController)


### PR DESCRIPTION
この変更を行う前は、コンソールに404のエラーが発生

変更を行うことで、重複読み込みがなくなり、404エラーは発生しなくなる